### PR TITLE
Fix/center home elder UI

### DIFF
--- a/app/src/main/java/com/konkuk/hackathon/core/common/component/OnItTopAppBar.kt
+++ b/app/src/main/java/com/konkuk/hackathon/core/common/component/OnItTopAppBar.kt
@@ -24,7 +24,8 @@ fun OnItTopAppBar(title: String, popBackStack: () -> Unit, modifier: Modifier = 
         Row(
             Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp),
+                .padding(horizontal = 16.dp)
+                .align(Alignment.Center),
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Icon(

--- a/app/src/main/java/com/konkuk/hackathon/core/navigation/center/CenterNavHost.kt
+++ b/app/src/main/java/com/konkuk/hackathon/core/navigation/center/CenterNavHost.kt
@@ -15,6 +15,7 @@ import com.konkuk.hackathon.feature.center.home.screen.AttentionRequiredScreen
 import com.konkuk.hackathon.feature.center.home.screen.CenterHomeScreen
 import com.konkuk.hackathon.feature.center.home.screen.ElderStatusScreen
 import com.konkuk.hackathon.feature.center.home.screen.RecordDetailScreen
+import com.konkuk.hackathon.feature.center.home.screen.VolunteerAllRecordScreen
 import com.konkuk.hackathon.feature.center.register.screen.RegisterScreen
 import com.konkuk.hackathon.feature.center.register.screen.SuccessRegisterScreen
 
@@ -44,7 +45,16 @@ fun CenterNavHost(
                 ElderStatusScreen(
                     padding = padding,
                     popBackStack = { navController.popBackStack() },
-                    navigateToRecordDetail = { navController.navigate(CenterRoute.RecordDetail) })
+                    navigateToRecordDetail = { navController.navigate(CenterRoute.RecordDetail) },
+                    navigateToAllRecord = { navController.navigate(CenterRoute.VolunteerAllRecord) })
+            }
+            composable<CenterRoute.VolunteerAllRecord> {
+                VolunteerAllRecordScreen(
+                    padding = padding, popBackStack = { navController.popBackStack() },
+                    navigateToRecordDetail = {
+                        navController.navigate(CenterRoute.RecordDetail)
+                    }
+                )
             }
             composable<CenterRoute.RecordDetail> {
                 RecordDetailScreen(
@@ -119,7 +129,7 @@ fun CenterNavHost(
         composable<CenterTabRoute.Settings> {
             CenterSettingScreen(
                 padding = padding,
-                onClickModify = {navController.navigate(CenterRoute.CenterInfoModify)},
+                onClickModify = { navController.navigate(CenterRoute.CenterInfoModify) },
             )
         }
 

--- a/app/src/main/java/com/konkuk/hackathon/core/navigation/center/CenterRoute.kt
+++ b/app/src/main/java/com/konkuk/hackathon/core/navigation/center/CenterRoute.kt
@@ -19,6 +19,9 @@ sealed interface CenterRoute {
     data object ElderStatus : CenterRoute
 
     @Serializable
+    data object VolunteerAllRecord : CenterRoute
+
+    @Serializable
     data object RecordDetail : CenterRoute
 
     @Serializable

--- a/app/src/main/java/com/konkuk/hackathon/feature/center/home/components/VolunteerMatchingChip.kt
+++ b/app/src/main/java/com/konkuk/hackathon/feature/center/home/components/VolunteerMatchingChip.kt
@@ -30,11 +30,13 @@ fun VolunteerMatchingChip(
         VolunteerMatchingType.DONE -> Negative_container
     }
 
-    Box(Modifier
-        .clip(RoundedCornerShape(10.dp))
-        .background(containerColor)) {
+    Box(
+        Modifier
+            .clip(RoundedCornerShape(10.dp))
+            .background(containerColor)
+    ) {
         Text(
-            "진행중",
+            volunteerMatchingType.label,
             style = OnItTheme.typography.B_12,
             color = textColor,
             modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp)

--- a/app/src/main/java/com/konkuk/hackathon/feature/center/home/components/VolunteerMatchingChip.kt
+++ b/app/src/main/java/com/konkuk/hackathon/feature/center/home/components/VolunteerMatchingChip.kt
@@ -1,0 +1,49 @@
+package com.konkuk.hackathon.feature.center.home.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import com.konkuk.hackathon.core.designsystem.theme.Negative
+import com.konkuk.hackathon.core.designsystem.theme.Negative_container
+import com.konkuk.hackathon.core.designsystem.theme.OnItTheme
+import com.konkuk.hackathon.core.designsystem.theme.Positive
+import com.konkuk.hackathon.core.designsystem.theme.Positive_container
+
+@Composable
+fun VolunteerMatchingChip(
+    volunteerMatchingType: VolunteerMatchingType,
+    modifier: Modifier = Modifier
+) {
+    val textColor = when (volunteerMatchingType) {
+        VolunteerMatchingType.ACTIVE -> Positive
+        VolunteerMatchingType.DONE -> Negative
+    }
+
+    val containerColor = when (volunteerMatchingType) {
+        VolunteerMatchingType.ACTIVE -> Positive_container
+        VolunteerMatchingType.DONE -> Negative_container
+    }
+
+    Box(Modifier
+        .clip(RoundedCornerShape(10.dp))
+        .background(containerColor)) {
+        Text(
+            "진행중",
+            style = OnItTheme.typography.B_12,
+            color = textColor,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp)
+        )
+    }
+}
+
+enum class VolunteerMatchingType(val label: String) {
+    ACTIVE("진행중"),
+    DONE("진행종료")
+
+}

--- a/app/src/main/java/com/konkuk/hackathon/feature/center/home/screen/ElderStatusScreen.kt
+++ b/app/src/main/java/com/konkuk/hackathon/feature/center/home/screen/ElderStatusScreen.kt
@@ -13,31 +13,41 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.konkuk.hackathon.R
 import com.konkuk.hackathon.core.common.component.CallStatusChip
 import com.konkuk.hackathon.core.common.component.OnItTopAppBar
 import com.konkuk.hackathon.core.data.model.CallStatusType
 import com.konkuk.hackathon.core.designsystem.theme.OnItTheme
+import com.konkuk.hackathon.core.designsystem.theme.Primary
 import com.konkuk.hackathon.core.designsystem.theme.gray2
 import com.konkuk.hackathon.core.designsystem.theme.gray4
+import com.konkuk.hackathon.core.designsystem.theme.gray5
 import com.konkuk.hackathon.core.designsystem.theme.gray7
+import com.konkuk.hackathon.feature.center.home.components.VolunteerMatchingChip
+import com.konkuk.hackathon.feature.center.home.components.VolunteerMatchingType
 
 @Composable
 fun ElderStatusScreen(
     padding: PaddingValues,
     popBackStack: () -> Unit,
     navigateToRecordDetail: () -> Unit,
+    navigateToAllRecord: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -54,21 +64,40 @@ fun ElderStatusScreen(
                 Text("활동 기록", style = OnItTheme.typography.SB_18, color = gray7)
                 Spacer(Modifier.height(24.dp))
             }
-            items(3) { index -> // 실제 데이터 리스트 넣기
-                val shape = when (index) {
-                    0 -> RoundedCornerShape(topStart = 14.dp, topEnd = 14.dp)
-                    2 -> RoundedCornerShape(
-                        bottomStart = 14.dp,
-                        bottomEnd = 14.dp
-                    ) // 마지막 index 일때로 수정 필요
-                    else -> RectangleShape
-                }
+            item {
                 Box(
                     Modifier
                         .fillMaxWidth()
-                        .clip(shape)
-                        .border(1.dp, gray2, shape)
-                        .clickable(onClick = navigateToRecordDetail )
+                        .clip(
+                            RoundedCornerShape(topStart = 14.dp, topEnd = 14.dp)
+                        )
+                        .border(
+                            width = 1.dp,
+                            color = gray2,
+                            shape = RoundedCornerShape(topStart = 14.dp, topEnd = 14.dp)
+                        )
+                ) {
+                    Column(Modifier.padding(16.dp)) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text("홍길동 봉사자", style = OnItTheme.typography.SB_16, color = gray7)
+                            Spacer(Modifier.width(6.dp))
+                            VolunteerMatchingChip(VolunteerMatchingType.ACTIVE)
+                        }
+                        Spacer(Modifier.height(8.dp))
+                        Text(
+                            "총 통화 x회 · 총 시간 x시간 x분 x초",
+                            style = OnItTheme.typography.R_14,
+                            color = gray5
+                        )
+                    }
+                }
+            }
+            items(3) { index -> // 실제 데이터 리스트 넣기
+                Box(
+                    Modifier
+                        .fillMaxWidth()
+                        .border(1.dp, gray2)
+                        .clickable(onClick = navigateToRecordDetail)
                 ) {
                     Row(
                         Modifier
@@ -77,21 +106,51 @@ fun ElderStatusScreen(
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Column {
+                        Row {
                             Text(
-                                "8/25(화) 홍길동 봉사자",
+                                "2025-08-26 19:32",
                                 style = OnItTheme.typography.R_15,
                                 color = gray7
                             ) // 실제 데이터로 변경 필요
-                            Spacer(Modifier.height(4.dp))
+                            Spacer(Modifier.width(8.dp))
                             Text(
-                                "통화시간 30분 24초",
+                                "00:33:22",
                                 style = OnItTheme.typography.R_14,
-                                color = gray4
+                                color = gray5
                             ) // 실제 데이터로 변경 필요
                         }
-                        CallStatusChip(CallStatusType.COMPLETE) // 실제 데이터로 변경 필요
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            CallStatusChip(CallStatusType.COMPLETE) // 실제 데이터로 변경 필요
+                            Icon(
+                                painter = painterResource(R.drawable.ic_arrow_back),
+                                contentDescription = "기록 상세 보기",
+                                Modifier.graphicsLayer(scaleX = -1f)
+                            )
+                        }
+
                     }
+                }
+            }
+            item {
+                Box(
+                    Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(bottomStart = 14.dp, bottomEnd = 14.dp))
+                        .border(
+                            1.dp,
+                            gray2,
+                            RoundedCornerShape(bottomStart = 14.dp, bottomEnd = 14.dp)
+                        )
+                        .clickable(onClick = {})
+                ) {
+                    Text(
+                        "전체 기록 보기",
+                        Modifier
+                            .padding(vertical = 20.dp)
+                            .align(Alignment.Center),
+                        style = OnItTheme.typography.SB_14,
+                        color = Primary
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/konkuk/hackathon/feature/center/home/screen/VolunteerAllRecordScreen.kt
+++ b/app/src/main/java/com/konkuk/hackathon/feature/center/home/screen/VolunteerAllRecordScreen.kt
@@ -15,16 +15,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -36,68 +33,38 @@ import com.konkuk.hackathon.core.data.model.CallStatusType
 import com.konkuk.hackathon.core.designsystem.theme.OnItTheme
 import com.konkuk.hackathon.core.designsystem.theme.Primary
 import com.konkuk.hackathon.core.designsystem.theme.gray2
-import com.konkuk.hackathon.core.designsystem.theme.gray4
 import com.konkuk.hackathon.core.designsystem.theme.gray5
 import com.konkuk.hackathon.core.designsystem.theme.gray7
 import com.konkuk.hackathon.feature.center.home.components.VolunteerMatchingChip
 import com.konkuk.hackathon.feature.center.home.components.VolunteerMatchingType
 
 @Composable
-fun ElderStatusScreen(
+fun VolunteerAllRecordScreen(
     padding: PaddingValues,
     popBackStack: () -> Unit,
     navigateToRecordDetail: () -> Unit,
-    navigateToAllRecord: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
+
     Column(
         Modifier
             .fillMaxSize()
             .background(OnItTheme.colors.white)
             .padding(padding)
     ) {
-        OnItTopAppBar("김순자 어르신", popBackStack) // 수정 필요
+        OnItTopAppBar("홍길동 봉사자", popBackStack) // 수정 필요
 
         LazyColumn(Modifier.padding(horizontal = 16.dp)) {
             item {
                 Spacer(Modifier.height(16.dp))
-                Text("활동 기록", style = OnItTheme.typography.SB_18, color = gray7)
-                Spacer(Modifier.height(24.dp))
+
             }
-            item {
-                Box(
-                    Modifier
-                        .fillMaxWidth()
-                        .clip(
-                            RoundedCornerShape(topStart = 14.dp, topEnd = 14.dp)
-                        )
-                        .border(
-                            width = 1.dp,
-                            color = gray2,
-                            shape = RoundedCornerShape(topStart = 14.dp, topEnd = 14.dp)
-                        )
-                ) {
-                    Column(Modifier.padding(16.dp)) {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Text("홍길동 봉사자", style = OnItTheme.typography.SB_16, color = gray7)
-                            Spacer(Modifier.width(6.dp))
-                            VolunteerMatchingChip(VolunteerMatchingType.ACTIVE)
-                        }
-                        Spacer(Modifier.height(8.dp))
-                        Text(
-                            "총 통화 x회 · 총 시간 x시간 x분 x초",
-                            style = OnItTheme.typography.R_14,
-                            color = gray5
-                        )
-                    }
-                }
-            }
-            items(3) { index -> // 실제 데이터 리스트 넣기
+            items(5) {
                 Box(
                     Modifier
                         .fillMaxWidth()
                         .border(1.dp, gray2)
-                        .clickable(onClick = { navigateToRecordDetail() })
+                        .clickable(onClick = navigateToRecordDetail)
                 ) {
                     Row(
                         Modifier
@@ -132,36 +99,18 @@ fun ElderStatusScreen(
                     }
                 }
             }
-            item {
-                Box(
-                    Modifier
-                        .fillMaxWidth()
-                        .clip(RoundedCornerShape(bottomStart = 14.dp, bottomEnd = 14.dp))
-                        .border(
-                            1.dp,
-                            gray2,
-                            RoundedCornerShape(bottomStart = 14.dp, bottomEnd = 14.dp)
-                        )
-                        .clickable(onClick = { navigateToAllRecord() })
-                ) {
-                    Text(
-                        "전체 기록 보기",
-                        Modifier
-                            .padding(vertical = 20.dp)
-                            .align(Alignment.Center),
-                        style = OnItTheme.typography.SB_14,
-                        color = Primary
-                    )
-                }
-            }
         }
     }
+
 }
+
 
 @Preview
 @Composable
-private fun ElderStatusPreview() {
-
-    ElderStatusScreen(padding = PaddingValues(), popBackStack = {}, {})
+private fun VARSPrev() {
+    VolunteerAllRecordScreen(
+        padding = PaddingValues(),
+        popBackStack = {},
+        navigateToRecordDetail = {})
 
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 봉사자 전체 기록 화면 추가: 전체 목록 조회 및 항목 선택으로 상세화면 이동.
  - 봉사 매칭 상태를 표시하는 칩(진행중/진행종료) 컴포넌트 추가.
- UI/UX
  - 상단 앱바 내용 수직 중앙 정렬로 시각적 균형 개선.
  - ElderStatus에 헤더(봉사자명 + 매칭 칩) 추가, 목록 카드 레이아웃 및 우측 화살표 아이콘 적용.
  - 목록 하단에 “전체 기록 보기” 버튼 추가.
- 내비게이션
  - 전체 기록 화면을 향한 신규 경로 및 뒤로가기/상세 이동 흐름 연동.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->